### PR TITLE
Remove unused datetime import

### DIFF
--- a/whatsapp_bot.py
+++ b/whatsapp_bot.py
@@ -1,6 +1,5 @@
 import os
 import json
-from datetime import datetime
 import schedule
 import time
 from flask import Flask, request, abort


### PR DESCRIPTION
## Summary
- drop unused `datetime` import from whatsapp bot

## Testing
- `python -m py_compile whatsapp_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e9323dd148320abb7435fe6c034ad